### PR TITLE
[service] statefs user session instance is run with -o allow_other

### DIFF
--- a/packaging/statefs.service.in
+++ b/packaging/statefs.service.in
@@ -7,7 +7,7 @@ Requires=dbus.socket
 
 [Service]
 ExecStartPre=@prefix@/bin/statefs-prerun
-ExecStart=@prefix@/bin/statefs ${XDG_RUNTIME_DIR}/state -f
+ExecStart=@prefix@/bin/statefs ${XDG_RUNTIME_DIR}/state -f -o allow_other
 Restart=always
 RestartSec=1
 

--- a/rpm/statefs.spec
+++ b/rpm/statefs.spec
@@ -16,6 +16,7 @@ BuildRequires: cmake >= 2.8
 BuildRequires: doxygen
 BuildRequires: pkgconfig(cor) >= %{cor_version}
 BuildRequires: systemd
+Requires: fuse >= 2.9.0-1.4
 %{?_with_usersession:Requires: systemd-user-session-targets}
 %description
 StateFS is the syntetic filesystem to expose current system state


### PR DESCRIPTION
To solve issues with access from applications run by user but under group
different from fs group

Signed-off-by: Denis Zalevskiy denis.zalevskiy@jolla.com
