### PR TITLE
[api] server provides run mode to provider

### DIFF
--- a/include/statefs/provider.h
+++ b/include/statefs/provider.h
@@ -254,13 +254,19 @@ typedef enum {
 
     // add new events above
     statefs_events_end
-}  statefs_event;
+} statefs_event;
+
+typedef enum {
+    statefs_provider_mode_dump,
+    statefs_provider_mode_run
+} statefs_provider_mode;
 
 struct statefs_server
 {
     void (*event)(struct statefs_server*
                   , struct statefs_provider*
                   , statefs_event);
+    statefs_provider_mode mode;
 };
 
 /**
@@ -293,7 +299,7 @@ static inline char const *statefs_provider_accessor()
  * if provider logic is changed and it can't be used with previous
  * versions of consumer safely
  */
-#define STATEFS_CURRENT_VERSION STATEFS_MK_VERSION(3, 1)
+#define STATEFS_CURRENT_VERSION STATEFS_MK_VERSION(3, 2)
 
 static inline bool statefs_is_version_compatible
 (unsigned own_version, unsigned lib_ver)

--- a/rpm/statefs.spec
+++ b/rpm/statefs.spec
@@ -152,12 +152,8 @@ rm -rf %{buildroot}
 %{_unitdir}/statefs.service
 %{_unitdir}/multi-user.target.wants/statefs.service
 %{_unitdir}/actdead-pre.target.wants/statefs.service
-%{_libdir}/libstatefs-config.so
-%{_libdir}/libstatefs-util.so
-%{_libdir}/libstatefs-config.so.0
-%{_libdir}/libstatefs-util.so.0
-%{_libdir}/libstatefs-config.so.%{version}
-%{_libdir}/libstatefs-util.so.%{version}
+%{_libdir}/libstatefs-config.so*
+%{_libdir}/libstatefs-util.so*
 %{_statefs_libdir}
 %{_statefs_libdir}/install-provider
 %{_statefs_libdir}/loader-do
@@ -189,9 +185,7 @@ rm -rf %{buildroot}
 
 %files pp
 %defattr(-,root,root,-)
-%{_libdir}/libstatefs-pp.so
-%{_libdir}/libstatefs-pp.so.0
-%{_libdir}/libstatefs-pp.so.%{version}
+%{_libdir}/libstatefs-pp.so*
 
 %files doc
 %defattr(-,root,root,-)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(statefs-config SHARED
 SET_TARGET_PROPERTIES(
   statefs-config
   PROPERTIES
-  SOVERSION 0
+  SOVERSION 1
   VERSION ${VERSION}
   )
 
@@ -39,7 +39,7 @@ add_library(statefs-pp
 SET_TARGET_PROPERTIES(
   statefs-pp
   PROPERTIES
-  SOVERSION 0
+  SOVERSION 1
   VERSION ${VERSION}
   )
 
@@ -58,7 +58,7 @@ target_link_libraries(statefs-util
 SET_TARGET_PROPERTIES(
   statefs-util
   PROPERTIES
-  SOVERSION 0
+  SOVERSION 1
   VERSION ${VERSION}
   )
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -679,6 +679,8 @@ static std::string dump_loader
     return cfg_loader_prefix() + "-" + loader_info->value();
 }
 
+static statefs_server config_server_info = { nullptr, statefs_provider_mode_dump };
+
 static std::string dump_provider
 (std::string const& cfg_dir, std::ostream &dst
  , fs::path const &path, std::string const& provider_type)
@@ -699,7 +701,7 @@ static std::string dump_provider
     }
 
     auto prov_info = from_api
-        (loader->load(path.native(), nullptr)
+        (loader->load(path.native(), &config_server_info)
          , path.native(), provider_type);
     if (!prov_info) {
         std::cerr << "Not provider, trying loader\n";

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -117,6 +117,7 @@ private:
     static statefs_server* init_server(statefs_server *s)
     {
         s->event = &ProviderBridge::on_event_;
+        s->mode = statefs_provider_mode_run;
         return s;
     }
 


### PR DESCRIPTION
2 modes: "dump" (to browse provider api and retrieve provider configuration) and
"run" (to run provider)

Signed-off-by: Denis Zalevskiy <denis.zalevskiy@jolla.com>