### PR TITLE
Fix packaging and make tests locale-independent

### DIFF
--- a/packaging/statefs-system.service.in
+++ b/packaging/statefs-system.service.in
@@ -12,7 +12,7 @@ Before=basic.target
 Conflicts=shutdown.target
 
 [Service]
-EnvironmentFile=@SYS_CONFIG_DIR@/system.conf
+EnvironmentFile=@SYS_CONFIG_DIR@/system*.conf
 ExecStartPre=@prefix@/bin/statefs-prerun
 ExecStart=@prefix@/bin/statefs /run/state -f --system -o allow_other,default_permissions,gid=${STATEFS_GID},file_umask=${STATEFS_UMASK}
 Restart=always

--- a/packaging/statefs.service.in
+++ b/packaging/statefs.service.in
@@ -6,7 +6,7 @@ Description=StateFS FUSE filesystem
 Requires=dbus.socket
 
 [Service]
-EnvironmentFile=@SYS_CONFIG_DIR@/session.conf
+EnvironmentFile=@SYS_CONFIG_DIR@/session*.conf
 ExecStartPre=@prefix@/bin/statefs-prerun
 ExecStart=@prefix@/bin/statefs ${XDG_RUNTIME_DIR}/state -f -o allow_other,default_permissions,file_umask=${STATEFS_UMASK}
 Restart=always

--- a/rpm/statefs.spec
+++ b/rpm/statefs.spec
@@ -148,7 +148,7 @@ rm -rf %{buildroot}
 %doc COPYING
 %{_bindir}/statefs
 %{_bindir}/statefs-prerun
-%{statefs_state_dir}
+%dir %{statefs_state_dir}
 %if 0%{?_with_usersession:1}
 %{_userunitdir}/statefs.service
 %{_userunitdir}/pre-user-session.target.wants/statefs.service
@@ -158,7 +158,7 @@ rm -rf %{buildroot}
 %{_unitdir}/actdead-pre.target.wants/statefs.service
 %{_libdir}/libstatefs-config.so*
 %{_libdir}/libstatefs-util.so*
-%{_statefs_libdir}
+%dir %{_statefs_libdir}
 %{_statefs_libdir}/install-provider
 %{_statefs_libdir}/loader-do
 %{_statefs_libdir}/provider-do
@@ -167,7 +167,7 @@ rm -rf %{buildroot}
 %{_statefs_libdir}/statefs-start
 %{_statefs_libdir}/statefs-stop
 %{_statefs_libdir}/once
-%{my_env_dir}
+%dir %{my_env_dir}
 %{_bindir}/statefs-watch
 %{_bindir}/statefs-change-notifier
 
@@ -195,6 +195,7 @@ rm -rf %{buildroot}
 
 %files doc
 %defattr(-,root,root,-)
+%dir %{_datarootdir}/doc/statefs
 %{_datarootdir}/doc/statefs/html/*
 
 %files examples -f examples.files
@@ -202,6 +203,7 @@ rm -rf %{buildroot}
 
 %files tests
 %defattr(-,root,root,-)
+%dir /opt/tests/statefs
 /opt/tests/statefs/*
 
 %post

--- a/tests/tests.xml.in
+++ b/tests/tests.xml.in
@@ -5,7 +5,7 @@
        <set name="unit-tests" feature="Statefs basic functionality">
            <description>Basic tests</description>
            <case manual="false" name="unittests">
-               <step>cd /opt/tests/statefs/ &amp;&amp; ./test-statefs.py @prefix@/bin/statefs @prefix@/@DST_LIB@/statefs/libloader-default.so</step>
+               <step>LANG=C cd /opt/tests/statefs/ &amp;&amp; ./test-statefs.py @prefix@/bin/statefs @prefix@/@DST_LIB@/statefs/libloader-default.so</step>
            </case>
        </set>
    </suite>


### PR DESCRIPTION
- Any @SYS_CONFIG_DIR@/*.conf can be used to set environment
- Missing %dir are added into spec
- explicitely set LANG=C for statefs tests, get rid of issues with missing locales in the testing environment
